### PR TITLE
Unpack ignition from different formats

### DIFF
--- a/rhcos-iso/extract_ignition_from_ai_iso.sh
+++ b/rhcos-iso/extract_ignition_from_ai_iso.sh
@@ -24,8 +24,16 @@ cp /mnt/discovery_iso/images/ignition.img /tmp/temporary_ignition/
 
 # extract the file
 pushd /tmp/temporary_ignition
-mv ignition.img ignition.img.xz
-unxz ignition.img.xz
+
+# detect file type, as it can change depending on versions
+FILE_TYPE=$(file ignition.img)
+if [[ $FILE_TYPE == *"XZ"* ]];then
+    mv ignition.img ignition.img.xz
+    unxz ignition.img.xz
+elif [[ $FILE_TYPE == *"gzip"* ]]; then
+    mv ignition.img ignition.img.gz
+    gunzip ignition.img.gz
+fi
 
 # extract with cpio
 cpio -idmv < ignition.img


### PR DESCRIPTION
Depending on the version of the image,
ignition comes packed into a different format.
So we need to check for the file type, and
uncompress accordingly.

Signed-off-by: Yolanda Robla <yroblamo@redhat.com>